### PR TITLE
feat(luthor_generator): validate method generates unique methods 

### DIFF
--- a/packages/luthor_generator/example/lib/another_sample.dart
+++ b/packages/luthor_generator/example/lib/another_sample.dart
@@ -17,7 +17,7 @@ class AnotherSample with _$AnotherSample {
   static SchemaValidationResult<AnotherSample> validate(
     Map<String, dynamic> json,
   ) =>
-      _$validate(json);
+      _$AnotherSampleValidate(json);
 
   factory AnotherSample.fromJson(Map<String, dynamic> json) =>
       _$AnotherSampleFromJson(json);

--- a/packages/luthor_generator/example/lib/another_sample.g.dart
+++ b/packages/luthor_generator/example/lib/another_sample.g.dart
@@ -27,5 +27,11 @@ Validator $AnotherSampleSchema = l.schema({
   'name': l.string(),
 });
 
-SchemaValidationResult<AnotherSample> _$validate(Map<String, dynamic> json) =>
+SchemaValidationResult<AnotherSample> _$AnotherSampleValidate(
+        Map<String, dynamic> json) =>
     $AnotherSampleSchema.validateSchema(json, fromJson: AnotherSample.fromJson);
+
+extension AnotherSampleValidationExtension on AnotherSample {
+  SchemaValidationResult<AnotherSample> validateSelf() =>
+      _$AnotherSampleValidate(toJson());
+}

--- a/packages/luthor_generator/example/lib/sample.dart
+++ b/packages/luthor_generator/example/lib/sample.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_annotation_target
+
 import 'package:example/another_sample.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:luthor/luthor.dart';
@@ -32,12 +34,21 @@ class Sample with _$Sample {
   }) = _Sample;
 
   static SchemaValidationResult<Sample> validate(Map<String, dynamic> json) =>
-      _$validate(json);
+      _$SampleValidate(json);
 
   factory Sample.fromJson(Map<String, dynamic> json) => _$SampleFromJson(json);
 }
 
 void main() {
-  final v = Sample.validate({});
-  print(v);
+  final result = Sample.validate({});
+  switch (result) {
+    case SchemaValidationError(errors: final errors):
+      print('Error: ');
+      errors.forEach((key, value) {
+        print('$key: $value');
+      });
+    case SchemaValidationSuccess(data: final data):
+      print('Success: $data');
+      data.validateSelf();
+  }
 }

--- a/packages/luthor_generator/example/lib/sample.freezed.dart
+++ b/packages/luthor_generator/example/lib/sample.freezed.dart
@@ -307,22 +307,15 @@ class _$_Sample implements _Sample {
       required final List<String> listValue,
       required this.numValue,
       required this.stringValue,
-      @isEmail
-          required this.email,
-      @isDateTime
-          required this.date,
-      @HasLength(10)
-          this.exactly10Characters,
-      @HasMin(8)
-      @HasMax(200)
-          required this.minAndMax,
-      @IsUri(allowedSchemes: ['https'])
-          this.httpsLink,
+      @isEmail required this.email,
+      @isDateTime required this.date,
+      @HasLength(10) this.exactly10Characters,
+      @HasMin(8) @HasMax(200) required this.minAndMax,
+      @IsUri(allowedSchemes: ['https']) this.httpsLink,
       @MatchRegex(r'^https:\/\/pub\.dev\/packages\/luthor')
-          required this.luthorPath,
+      required this.luthorPath,
       required this.anotherSample,
-      @JsonKey(name: 'jsonKeyName')
-          required this.foo})
+      @JsonKey(name: 'jsonKeyName') required this.foo})
       : _listValue = listValue;
 
   factory _$_Sample.fromJson(Map<String, dynamic> json) =>
@@ -456,22 +449,15 @@ abstract class _Sample implements Sample {
       required final List<String> listValue,
       required final num numValue,
       required final String stringValue,
-      @isEmail
-          required final String email,
-      @isDateTime
-          required final String date,
-      @HasLength(10)
-          final String? exactly10Characters,
-      @HasMin(8)
-      @HasMax(200)
-          required final String minAndMax,
-      @IsUri(allowedSchemes: ['https'])
-          final String? httpsLink,
+      @isEmail required final String email,
+      @isDateTime required final String date,
+      @HasLength(10) final String? exactly10Characters,
+      @HasMin(8) @HasMax(200) required final String minAndMax,
+      @IsUri(allowedSchemes: ['https']) final String? httpsLink,
       @MatchRegex(r'^https:\/\/pub\.dev\/packages\/luthor')
-          required final String luthorPath,
+      required final String luthorPath,
       required final AnotherSample anotherSample,
-      @JsonKey(name: 'jsonKeyName')
-          required final String foo}) = _$_Sample;
+      @JsonKey(name: 'jsonKeyName') required final String foo}) = _$_Sample;
 
   factory _Sample.fromJson(Map<String, dynamic> json) = _$_Sample.fromJson;
 

--- a/packages/luthor_generator/example/lib/sample.g.dart
+++ b/packages/luthor_generator/example/lib/sample.g.dart
@@ -67,5 +67,9 @@ Validator $SampleSchema = l.schema({
   'jsonKeyName': l.string().required(),
 });
 
-SchemaValidationResult<Sample> _$validate(Map<String, dynamic> json) =>
+SchemaValidationResult<Sample> _$SampleValidate(Map<String, dynamic> json) =>
     $SampleSchema.validateSchema(json, fromJson: Sample.fromJson);
+
+extension SampleValidationExtension on Sample {
+  SchemaValidationResult<Sample> validateSelf() => _$SampleValidate(toJson());
+}

--- a/packages/luthor_generator/lib/generators/luthor_generator.dart
+++ b/packages/luthor_generator/lib/generators/luthor_generator.dart
@@ -46,9 +46,9 @@ class LuthorGenerator extends GeneratorForAnnotation<Luthor> {
         validateMethod.returnType.toString() != 'SchemaValidationResult<$name>';
     if (isInvalidMethod) {
       throw InvalidGenerationSourceError(
-        'Luthor can only be applied to classes with a static validate method. '
+        'Luthor can only be applied to classes with a validate method. '
         'Add the following code to your class:\n'
-        'static SchemaValidationResult<$name> validate(Map<String, dynamic> json) => _\$validate(json);',
+        'static SchemaValidationResult<$name> validate(Map<String, dynamic> json) => _\$${name}Validate(json);',
         element: element,
       );
     }
@@ -77,13 +77,23 @@ class LuthorGenerator extends GeneratorForAnnotation<Luthor> {
 
     _writeValidateMethod(buffer, name);
 
+    _writeExtension(buffer, name);
+
     return buffer.toString();
   }
 
   void _writeValidateMethod(StringBuffer buffer, String name) {
     buffer.write(
-      'SchemaValidationResult<$name> _\$validate(Map<String, dynamic> json) => '
+      'SchemaValidationResult<$name> _\$${name}Validate(Map<String, dynamic> json) => '
       '\$${name}Schema.validateSchema(json, fromJson: $name.fromJson);',
+    );
+  }
+
+  void _writeExtension(StringBuffer buffer, String name) {
+    buffer.write(
+      '\n\nextension ${name}ValidationExtension on $name {\n'
+      '  SchemaValidationResult<$name> validateSelf() => _\$${name}Validate(toJson());\n'
+      '}\n',
     );
   }
 }

--- a/packages/luthor_generator/lib/generators/luthor_generator.dart
+++ b/packages/luthor_generator/lib/generators/luthor_generator.dart
@@ -46,7 +46,7 @@ class LuthorGenerator extends GeneratorForAnnotation<Luthor> {
         validateMethod.returnType.toString() != 'SchemaValidationResult<$name>';
     if (isInvalidMethod) {
       throw InvalidGenerationSourceError(
-        'Luthor can only be applied to classes with a validate method. '
+        'Luthor can only be applied to classes with a static validate method. '
         'Add the following code to your class:\n'
         'static SchemaValidationResult<$name> validate(Map<String, dynamic> json) => _\$${name}Validate(json);',
         element: element,


### PR DESCRIPTION
This change allows multiple luthor classes in one file
This PR also adds a `validateSelf` method. This allows for an object to validate itself. Useful when working with forms in Flutter

#### Before
```dart
final SomeLuthorClass obj = SomeLuthorClass(/* some fields */);
final SchemaValidationResult<SomeLuthorClass> result = SomeLuthorClass.validate(obj.toJson());
```

#### After
```dart
final SomeLuthorClass obj = SomeLuthorClass(/* some fields */);
final SchemaValidationResult<SomeLuthorClass> result = obj.validateSelf();
```